### PR TITLE
Add an option to hide maintenance service

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ esp32_ble_controller:
   # This automation is not available for the "none" mode, optional for the "bond" mode, and required for the "secure" mode.
   security_mode: secure
 
+  # Whether to expose the maintenance service, which allows viewing logs, or executing commands.
+  # When set to 'false', the service is not exposed.
+  # Useful when security is set to 'none' so there is no risk that the node will be abused.
+  expose_maintenance_service: true
+
   # automation that is invoked when the pass key should be displayed, the pass key is available in the automation as "pass_key" variable of type std::string (not available if security mode is "none")
   # the example below just logs the pass keys
   on_show_pass_key:

--- a/components/esp32_ble_controller/__init__.py
+++ b/components/esp32_ble_controller/__init__.py
@@ -24,6 +24,7 @@ CONF_BLE_CHARACTERISTICS = "characteristics"
 CONF_BLE_CHARACTERISTIC = "characteristic"
 CONF_BLE_USE_2902 = "use_BLE2902"
 CONF_EXPOSES_COMPONENT = "exposes"
+CONF_EXPOSE_MAINTENANCE_SERVICE = "expose_maintenance_service"
 
 def validate_UUID(value):
     # print("UUID«", value)
@@ -122,6 +123,8 @@ BLEControllerServerDisconnectedTrigger = esp32_ble_controller_ns.class_('BLECont
 CONFIG_SCHEMA = cv.All(cv.only_on_esp32, cv.Schema({
     cv.GenerateID(): cv.declare_id(ESP32BLEController),
 
+    cv.Optional(CONF_EXPOSE_MAINTENANCE_SERVICE, default=True): cv.boolean,
+
     cv.Optional(CONF_BLE_SERVICES): cv.ensure_list(BLE_SERVICE),
 
     cv.Optional(CONF_BLE_COMMANDS): cv.ensure_list(BLE_COMMAND),
@@ -187,6 +190,8 @@ def to_code(config):
 
     security_enabled = SECURTY_MODE_OPTIONS[config[CONF_SECURITY_MODE]]
     cg.add(var.set_security_mode(config[CONF_SECURITY_MODE]))
+
+    cg.add(var.set_maintenance_service_exposed(config[CONF_EXPOSE_MAINTENANCE_SERVICE]))
 
     for conf in config.get(CONF_ON_SHOW_PASS_KEY, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)

--- a/components/esp32_ble_controller/ble_maintenance_handler.h
+++ b/components/esp32_ble_controller/ble_maintenance_handler.h
@@ -30,7 +30,7 @@ public:
   BLEMaintenanceHandler();
   virtual ~BLEMaintenanceHandler() {}
 
-  void setup(BLEServer* ble_server);
+  void setup(BLEServer* ble_server, bool exposed);
 
   void add_command(BLECommand* command) { commands.push_back(command); }
   const vector<BLECommand*>& get_commands() const { return commands; }
@@ -47,7 +47,7 @@ public:
 
 private:
   virtual void onWrite(BLECharacteristic *characteristic) override;
-  void on_command_written();
+  void on_command_written(string command_line);
 
   bool is_security_enabled();
   

--- a/components/esp32_ble_controller/esp32_ble_controller.cpp
+++ b/components/esp32_ble_controller/esp32_ble_controller.cpp
@@ -138,7 +138,7 @@ void ESP32BLEController::setup_ble_server_and_services() {
   ble_server = BLEDevice::createServer();
   ble_server->setCallbacks(this);
 
-  maintenance_handler->setup(ble_server);
+  maintenance_handler->setup(ble_server, get_maintenance_service_exposed());
 
   if (get_ble_mode() != BLEMaintenanceMode::WIFI_ONLY) {
     setup_ble_services_for_components();
@@ -299,6 +299,7 @@ void ESP32BLEController::dump_config() {
   ESP_LOGCONFIG(TAG, "Bluetooth Low Energy Controller:");
   ESP_LOGCONFIG(TAG, "  BLE device address: %s", BLEDevice::getAddress().toString().c_str());
   ESP_LOGCONFIG(TAG, "  BLE mode: %d", (uint8_t) ble_mode);
+  ESP_LOGCONFIG(TAG, "  Maintenance service exposed: %s", maintenance_service_exposed ? "true" : "false");
 
   if (get_security_mode() != NONE) {
     if (get_security_mode() == BOND) {

--- a/components/esp32_ble_controller/esp32_ble_controller.h
+++ b/components/esp32_ble_controller/esp32_ble_controller.h
@@ -57,6 +57,9 @@ public:
   void set_security_mode(BLESecurityMode mode) { security_mode = mode; }
   inline BLESecurityMode get_security_mode() const { return security_mode; }
 
+  void set_maintenance_service_exposed(bool exposed) { maintenance_service_exposed = exposed; }
+  inline bool get_maintenance_service_exposed() const { return maintenance_service_exposed; }
+
   // deprecated
   void set_security_enabled(bool enabled);
   inline bool get_security_enabled() const { return security_mode != NONE; }
@@ -149,6 +152,8 @@ private:
 
   BLESecurityMode security_mode{SECURE};
   bool can_show_pass_key{false};
+
+  bool maintenance_service_exposed{true};
 
   BLEMaintenanceHandler* maintenance_handler;
 


### PR DESCRIPTION
With a disclaimer that my C++ knowledge infinitely approaches 0, that's what I did to add an option to hide the maintenance service in my fork.

Not sure if it will be helpful at all, but would be glad to see this functionality implemented in `esphome-ble-controller`.

Addresses #10