### PR TITLE
Add an option for a static passkey during pairing

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ esp32_ble_controller:
   # sends a 6-digit pass key to the ESP and the ESP is supposed to display it so that it can be entered on the other device.
   # This automation is not available for the "none" mode, optional for the "bond" mode, and required for the "secure" mode.
   security_mode: secure
-
+  # This allows setting a static passkey
+  static_passkey: "654321"
   # allows to disable the maintenance service, default is 'true'
   # When 'false', the maintenance service is not exposed, which provides at least some protection when security mode is "none".
   # Note: Writeable characteristics like those for switches or fans may still be written by basically anyone.

--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ esp32_ble_controller:
   # sends a 6-digit pass key to the ESP and the ESP is supposed to display it so that it can be entered on the other device.
   # This automation is not available for the "none" mode, optional for the "bond" mode, and required for the "secure" mode.
   security_mode: secure
-  # This optionally allows setting a static passkey instead of randomly generating one. This allows pairing on devices that
-  # don't have a convienent way to display a pass key. If this not set a random passkey will be generated.
+  # This optionally allows setting a static predefined passkey instead of randomly generating one for pairing. This allows
+  # pairing on devices that don't have a convienent way to display a pass key. If this not set a random passkey will be generated.
   static_passkey: "654321"
   # allows to disable the maintenance service, default is 'true'
   # When 'false', the maintenance service is not exposed, which provides at least some protection when security mode is "none".

--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ esp32_ble_controller:
   # sends a 6-digit pass key to the ESP and the ESP is supposed to display it so that it can be entered on the other device.
   # This automation is not available for the "none" mode, optional for the "bond" mode, and required for the "secure" mode.
   security_mode: secure
-  # This allows setting a static passkey
+  # This optionally allows setting a static passkey instead of randomly generating one. This allows pairing on devices that
+  # don't have a convienent way to display a pass key. If this not set a random passkey will be generated.
   static_passkey: "654321"
   # allows to disable the maintenance service, default is 'true'
   # When 'false', the maintenance service is not exposed, which provides at least some protection when security mode is "none".

--- a/components/esp32_ble_controller/__init__.py
+++ b/components/esp32_ble_controller/__init__.py
@@ -130,7 +130,7 @@ CONFIG_SCHEMA = cv.All(cv.only_on_esp32, cv.only_with_arduino, cv.Schema({
 
     cv.Optional(CONF_BLE_COMMANDS): cv.ensure_list(BLE_COMMAND),
 
-    cv.Optional(CONF_STATIC_PASSKEY): cv.string,
+    cv.Optional(CONF_STATIC_PASSKEY): cv.int_,
 
     cv.Optional(CONF_EXPOSE_MAINTENANCE_SERVICE, default=True): cv.boolean,
 

--- a/components/esp32_ble_controller/__init__.py
+++ b/components/esp32_ble_controller/__init__.py
@@ -130,7 +130,7 @@ CONFIG_SCHEMA = cv.All(cv.only_on_esp32, cv.only_with_arduino, cv.Schema({
 
     cv.Optional(CONF_BLE_COMMANDS): cv.ensure_list(BLE_COMMAND),
 
-    cv.Optional(CONF_STATIC_PASSKEY): cv.integer,
+    cv.Optional(CONF_STATIC_PASSKEY): cv.int,
 
     cv.Optional(CONF_EXPOSE_MAINTENANCE_SERVICE, default=True): cv.boolean,
 

--- a/components/esp32_ble_controller/__init__.py
+++ b/components/esp32_ble_controller/__init__.py
@@ -130,6 +130,8 @@ CONFIG_SCHEMA = cv.All(cv.only_on_esp32, cv.only_with_arduino, cv.Schema({
 
     cv.Optional(CONF_BLE_COMMANDS): cv.ensure_list(BLE_COMMAND),
 
+    cv.Optional(CONF_STATIC_PASSKEY): cv.integer,
+
     cv.Optional(CONF_EXPOSE_MAINTENANCE_SERVICE, default=True): cv.boolean,
 
     cv.Optional(CONF_SECURITY_MODE, default=CONF_SECURITY_MODE_SECURE): cv.enum(SECURTY_MODE_OPTIONS),

--- a/components/esp32_ble_controller/__init__.py
+++ b/components/esp32_ble_controller/__init__.py
@@ -87,6 +87,7 @@ SECURTY_MODE_OPTIONS = {
     CONF_SECURITY_MODE_SECURE: BLESecurityMode.SECURE,
 }
 
+CONF_STATIC_PASSKEY = 'static_passkey'
 # authetication and (dis)connected automations #####
 CONF_ON_SHOW_PASS_KEY = "on_show_pass_key"
 BLEControllerShowPassKeyTrigger = esp32_ble_controller_ns.class_('BLEControllerShowPassKeyTrigger', automation.Trigger.template())

--- a/components/esp32_ble_controller/__init__.py
+++ b/components/esp32_ble_controller/__init__.py
@@ -197,6 +197,9 @@ def to_code(config):
 
     security_enabled = SECURTY_MODE_OPTIONS[config[CONF_SECURITY_MODE]]
     cg.add(var.set_security_mode(config[CONF_SECURITY_MODE]))
+    
+    static_passkey= SECURTY_MODE_OPTIONS[config[CONF_STATIC_PASSKEY]]
+    cg.add(var.set_static_passkey(config[CONF_STATIC_PASSKEY]))
 
     for conf in config.get(CONF_ON_SHOW_PASS_KEY, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)

--- a/components/esp32_ble_controller/__init__.py
+++ b/components/esp32_ble_controller/__init__.py
@@ -130,7 +130,7 @@ CONFIG_SCHEMA = cv.All(cv.only_on_esp32, cv.only_with_arduino, cv.Schema({
 
     cv.Optional(CONF_BLE_COMMANDS): cv.ensure_list(BLE_COMMAND),
 
-    cv.Optional(CONF_STATIC_PASSKEY): cv.int_,
+    cv.Optional(CONF_STATIC_PASSKEY, default=-1): cv.int_,
 
     cv.Optional(CONF_EXPOSE_MAINTENANCE_SERVICE, default=True): cv.boolean,
 

--- a/components/esp32_ble_controller/__init__.py
+++ b/components/esp32_ble_controller/__init__.py
@@ -198,7 +198,7 @@ def to_code(config):
     security_enabled = SECURTY_MODE_OPTIONS[config[CONF_SECURITY_MODE]]
     cg.add(var.set_security_mode(config[CONF_SECURITY_MODE]))
     
-    static_passkey= SECURTY_MODE_OPTIONS[config[CONF_STATIC_PASSKEY]]
+    static_passkey = config[CONF_STATIC_PASSKEY]
     cg.add(var.set_static_passkey(config[CONF_STATIC_PASSKEY]))
 
     for conf in config.get(CONF_ON_SHOW_PASS_KEY, []):

--- a/components/esp32_ble_controller/__init__.py
+++ b/components/esp32_ble_controller/__init__.py
@@ -130,7 +130,7 @@ CONFIG_SCHEMA = cv.All(cv.only_on_esp32, cv.only_with_arduino, cv.Schema({
 
     cv.Optional(CONF_BLE_COMMANDS): cv.ensure_list(BLE_COMMAND),
 
-    cv.Optional(CONF_STATIC_PASSKEY): cv.char_array,
+    cv.Optional(CONF_STATIC_PASSKEY): cv.string,
 
     cv.Optional(CONF_EXPOSE_MAINTENANCE_SERVICE, default=True): cv.boolean,
 

--- a/components/esp32_ble_controller/__init__.py
+++ b/components/esp32_ble_controller/__init__.py
@@ -130,7 +130,7 @@ CONFIG_SCHEMA = cv.All(cv.only_on_esp32, cv.only_with_arduino, cv.Schema({
 
     cv.Optional(CONF_BLE_COMMANDS): cv.ensure_list(BLE_COMMAND),
 
-    cv.Optional(CONF_STATIC_PASSKEY): cv.int_,
+    cv.Optional(CONF_STATIC_PASSKEY): cv.char_array,
 
     cv.Optional(CONF_EXPOSE_MAINTENANCE_SERVICE, default=True): cv.boolean,
 

--- a/components/esp32_ble_controller/__init__.py
+++ b/components/esp32_ble_controller/__init__.py
@@ -130,7 +130,7 @@ CONFIG_SCHEMA = cv.All(cv.only_on_esp32, cv.only_with_arduino, cv.Schema({
 
     cv.Optional(CONF_BLE_COMMANDS): cv.ensure_list(BLE_COMMAND),
 
-    cv.Optional(CONF_STATIC_PASSKEY): cv.int,
+    cv.Optional(CONF_STATIC_PASSKEY): cv.int_,
 
     cv.Optional(CONF_EXPOSE_MAINTENANCE_SERVICE, default=True): cv.boolean,
 

--- a/components/esp32_ble_controller/esp32_ble_controller.cpp
+++ b/components/esp32_ble_controller/esp32_ble_controller.cpp
@@ -451,7 +451,7 @@ void ESP32BLEController::configure_ble_security() {
   security.setRespEncryptionKey(ESP_BLE_ENC_KEY_MASK | ESP_BLE_ID_KEY_MASK);
   security.setKeySize(16);
   if(static_passkey) {
-    security.setStaticPIN(static_passkey_value)
+    security.setStaticPIN(static_passkey_value);
   }
 
   uint8_t auth_option = ESP_BLE_ONLY_ACCEPT_SPECIFIED_AUTH_ENABLE;

--- a/components/esp32_ble_controller/esp32_ble_controller.cpp
+++ b/components/esp32_ble_controller/esp32_ble_controller.cpp
@@ -79,7 +79,7 @@ void ESP32BLEController::set_security_enabled(bool enabled) {
   set_security_mode(BLESecurityMode::SECURE);
 }
 
-void ESP32BLEController::set_static_passkey(char passkey[6]) {
+void ESP32BLEController::set_static_passkey(char *passkey[6]) {
   static_passkey = true;
   static_passkey_value = passkey;
 }

--- a/components/esp32_ble_controller/esp32_ble_controller.cpp
+++ b/components/esp32_ble_controller/esp32_ble_controller.cpp
@@ -23,7 +23,7 @@ static const char *TAG = "esp32_ble_controller";
 
 
 boolean static_passkey = false;
-char static_passkey_value[6];
+char *static_passkey_value[6]; 
 
 ESP32BLEController::ESP32BLEController() : maintenance_handler(new BLEMaintenanceHandler()) {}
 

--- a/components/esp32_ble_controller/esp32_ble_controller.cpp
+++ b/components/esp32_ble_controller/esp32_ble_controller.cpp
@@ -79,7 +79,7 @@ void ESP32BLEController::set_security_enabled(bool enabled) {
   set_security_mode(BLESecurityMode::SECURE);
 }
 
-void ESP32BLEController::set_static_passkey(char &passkey[6]) {
+void ESP32BLEController::set_static_passkey(char passkey[6]) {
   static_passkey = true;
   static_passkey_value = passkey;
 }

--- a/components/esp32_ble_controller/esp32_ble_controller.cpp
+++ b/components/esp32_ble_controller/esp32_ble_controller.cpp
@@ -79,10 +79,14 @@ void ESP32BLEController::set_security_enabled(bool enabled) {
   set_security_mode(BLESecurityMode::SECURE);
 }
 
+//if a static passkey is not set the value will be -1
 void ESP32BLEController::set_static_passkey(uint32_t passkey) {
-  static_passkey = true;
-  static_passkey_value = passkey;
+  if(passkey > 0) {
+    static_passkey = true;
+    static_passkey_value = passkey;
+  }
 }
+
 
 
 /// setup ///////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/components/esp32_ble_controller/esp32_ble_controller.cpp
+++ b/components/esp32_ble_controller/esp32_ble_controller.cpp
@@ -79,9 +79,9 @@ void ESP32BLEController::set_security_enabled(bool enabled) {
   set_security_mode(BLESecurityMode::SECURE);
 }
 
-void ESP32BLEController::set_static_passkey(char passkey[6]) {
+void ESP32BLEController::set_static_passkey(std::string passkey) {
   static_passkey = true;
-  static_passkey_value = passkey;
+  std::snprintf(static_passkey_value, 6, "%s", passkey.c_str());
 }
 
 

--- a/components/esp32_ble_controller/esp32_ble_controller.cpp
+++ b/components/esp32_ble_controller/esp32_ble_controller.cpp
@@ -23,7 +23,7 @@ static const char *TAG = "esp32_ble_controller";
 
 
 boolean static_passkey = false;
-char static_passkey_value[6] = '';
+char static_passkey_value[6];
 
 ESP32BLEController::ESP32BLEController() : maintenance_handler(new BLEMaintenanceHandler()) {}
 

--- a/components/esp32_ble_controller/esp32_ble_controller.cpp
+++ b/components/esp32_ble_controller/esp32_ble_controller.cpp
@@ -79,7 +79,7 @@ void ESP32BLEController::set_security_enabled(bool enabled) {
   set_security_mode(BLESecurityMode::SECURE);
 }
 
-void ESP32BLEController::set_static_passkey(char *passkey[6]) {
+void ESP32BLEController::set_static_passkey(char &passkey[6]) {
   static_passkey = true;
   static_passkey_value = passkey;
 }

--- a/components/esp32_ble_controller/esp32_ble_controller.cpp
+++ b/components/esp32_ble_controller/esp32_ble_controller.cpp
@@ -23,7 +23,7 @@ static const char *TAG = "esp32_ble_controller";
 
 
 boolean static_passkey = false;
-char *static_passkey_value[6]; 
+char *static_passkey_value; 
 
 ESP32BLEController::ESP32BLEController() : maintenance_handler(new BLEMaintenanceHandler()) {}
 

--- a/components/esp32_ble_controller/esp32_ble_controller.cpp
+++ b/components/esp32_ble_controller/esp32_ble_controller.cpp
@@ -23,7 +23,7 @@ static const char *TAG = "esp32_ble_controller";
 
 
 boolean static_passkey = false;
-char[6] static_passkey_value;
+char* static_passkey_value[6];
 
 ESP32BLEController::ESP32BLEController() : maintenance_handler(new BLEMaintenanceHandler()) {}
 
@@ -79,9 +79,9 @@ void ESP32BLEController::set_security_enabled(bool enabled) {
   set_security_mode(BLESecurityMode::SECURE);
 }
 
-void ESP32BLEController::set_static_passkey(char[6] passkey) {
+void ESP32BLEController::set_static_passkey(PROGMEM char[6] passkey) {
   static_passkey = true;
-  static_passkey_value = passkey;
+  static_passkey_value = &passkey;
 }
 
 

--- a/components/esp32_ble_controller/esp32_ble_controller.cpp
+++ b/components/esp32_ble_controller/esp32_ble_controller.cpp
@@ -23,7 +23,7 @@ static const char *TAG = "esp32_ble_controller";
 
 
 boolean static_passkey = false;
-char[6] static_passkey_value = '123456';
+char[6] static_passkey_value;
 
 ESP32BLEController::ESP32BLEController() : maintenance_handler(new BLEMaintenanceHandler()) {}
 

--- a/components/esp32_ble_controller/esp32_ble_controller.cpp
+++ b/components/esp32_ble_controller/esp32_ble_controller.cpp
@@ -21,6 +21,10 @@ namespace esp32_ble_controller {
 
 static const char *TAG = "esp32_ble_controller";
 
+
+boolean static_passkey = false;
+int static_passkey_value = 0;
+
 ESP32BLEController::ESP32BLEController() : maintenance_handler(new BLEMaintenanceHandler()) {}
 
 /// pre-setup configuration ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -76,7 +80,8 @@ void ESP32BLEController::set_security_enabled(bool enabled) {
 }
 
 void ESP32BLEController::set_static_passkey(int passkey) {
-  return;
+  static_passkey = true;
+  static_passkey_value = passkey;
 }
 
 

--- a/components/esp32_ble_controller/esp32_ble_controller.cpp
+++ b/components/esp32_ble_controller/esp32_ble_controller.cpp
@@ -75,6 +75,11 @@ void ESP32BLEController::set_security_enabled(bool enabled) {
   set_security_mode(BLESecurityMode::SECURE);
 }
 
+void ESP32BLEController::set_static_passkey(int passkey) {
+  return;
+}
+
+
 /// setup ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 void ESP32BLEController::setup() {

--- a/components/esp32_ble_controller/esp32_ble_controller.cpp
+++ b/components/esp32_ble_controller/esp32_ble_controller.cpp
@@ -23,7 +23,7 @@ static const char *TAG = "esp32_ble_controller";
 
 
 boolean static_passkey = false;
-int static_passkey_value = 0;
+char[6] static_passkey_value = '';
 
 ESP32BLEController::ESP32BLEController() : maintenance_handler(new BLEMaintenanceHandler()) {}
 
@@ -79,7 +79,7 @@ void ESP32BLEController::set_security_enabled(bool enabled) {
   set_security_mode(BLESecurityMode::SECURE);
 }
 
-void ESP32BLEController::set_static_passkey(int passkey) {
+void ESP32BLEController::set_static_passkey(char[6] passkey) {
   static_passkey = true;
   static_passkey_value = passkey;
 }

--- a/components/esp32_ble_controller/esp32_ble_controller.cpp
+++ b/components/esp32_ble_controller/esp32_ble_controller.cpp
@@ -23,7 +23,7 @@ static const char *TAG = "esp32_ble_controller";
 
 
 boolean static_passkey = false;
-char[6] static_passkey_value = '';
+char[6] static_passkey_value = '123456';
 
 ESP32BLEController::ESP32BLEController() : maintenance_handler(new BLEMaintenanceHandler()) {}
 

--- a/components/esp32_ble_controller/esp32_ble_controller.cpp
+++ b/components/esp32_ble_controller/esp32_ble_controller.cpp
@@ -23,7 +23,7 @@ static const char *TAG = "esp32_ble_controller";
 
 
 boolean static_passkey = false;
-char *static_passkey_value; 
+uint32_t static_passkey_value; 
 
 ESP32BLEController::ESP32BLEController() : maintenance_handler(new BLEMaintenanceHandler()) {}
 
@@ -79,9 +79,9 @@ void ESP32BLEController::set_security_enabled(bool enabled) {
   set_security_mode(BLESecurityMode::SECURE);
 }
 
-void ESP32BLEController::set_static_passkey(std::string passkey) {
+void ESP32BLEController::set_static_passkey(uint32_t passkey) {
   static_passkey = true;
-  std::snprintf(static_passkey_value, 6, "%s", passkey.c_str());
+  static_passkey_value = passkey;
 }
 
 
@@ -450,6 +450,9 @@ void ESP32BLEController::configure_ble_security() {
   security.setInitEncryptionKey(ESP_BLE_ENC_KEY_MASK | ESP_BLE_ID_KEY_MASK);
   security.setRespEncryptionKey(ESP_BLE_ENC_KEY_MASK | ESP_BLE_ID_KEY_MASK);
   security.setKeySize(16);
+  if(static_passkey) {
+    security.setStaticPIN(static_passkey_value)
+  }
 
   uint8_t auth_option = ESP_BLE_ONLY_ACCEPT_SPECIFIED_AUTH_ENABLE;
   esp_ble_gap_set_security_param(ESP_BLE_SM_ONLY_ACCEPT_SPECIFIED_SEC_AUTH, &auth_option, sizeof(uint8_t));

--- a/components/esp32_ble_controller/esp32_ble_controller.cpp
+++ b/components/esp32_ble_controller/esp32_ble_controller.cpp
@@ -23,7 +23,7 @@ static const char *TAG = "esp32_ble_controller";
 
 
 boolean static_passkey = false;
-char* static_passkey_value[6];
+char static_passkey_value[6] = '';
 
 ESP32BLEController::ESP32BLEController() : maintenance_handler(new BLEMaintenanceHandler()) {}
 
@@ -79,9 +79,9 @@ void ESP32BLEController::set_security_enabled(bool enabled) {
   set_security_mode(BLESecurityMode::SECURE);
 }
 
-void ESP32BLEController::set_static_passkey(PROGMEM char[6] passkey) {
+void ESP32BLEController::set_static_passkey(char passkey[6]) {
   static_passkey = true;
-  static_passkey_value = &passkey;
+  static_passkey_value = passkey;
 }
 
 

--- a/components/esp32_ble_controller/esp32_ble_controller.h
+++ b/components/esp32_ble_controller/esp32_ble_controller.h
@@ -57,7 +57,7 @@ public:
   void add_on_disconnected_callback(std::function<void()>&& trigger_function);
 
   void set_maintenance_service_exposed_after_flash(bool exposed);
-  void set_static_passkey(*char);
+  void set_static_passkey(char key_pass[6]);
 
   void set_security_mode(BLESecurityMode mode) { security_mode = mode; }
   inline BLESecurityMode get_security_mode() const { return security_mode; }

--- a/components/esp32_ble_controller/esp32_ble_controller.h
+++ b/components/esp32_ble_controller/esp32_ble_controller.h
@@ -57,7 +57,7 @@ public:
   void add_on_disconnected_callback(std::function<void()>&& trigger_function);
 
   void set_maintenance_service_exposed_after_flash(bool exposed);
-  void set_static_passkey(*char[6]);
+  void set_static_passkey(&char[6]);
 
   void set_security_mode(BLESecurityMode mode) { security_mode = mode; }
   inline BLESecurityMode get_security_mode() const { return security_mode; }

--- a/components/esp32_ble_controller/esp32_ble_controller.h
+++ b/components/esp32_ble_controller/esp32_ble_controller.h
@@ -57,7 +57,7 @@ public:
   void add_on_disconnected_callback(std::function<void()>&& trigger_function);
 
   void set_maintenance_service_exposed_after_flash(bool exposed);
-  void set_static_passkey(int);
+  void set_static_passkey(char[6]);
 
   void set_security_mode(BLESecurityMode mode) { security_mode = mode; }
   inline BLESecurityMode get_security_mode() const { return security_mode; }

--- a/components/esp32_ble_controller/esp32_ble_controller.h
+++ b/components/esp32_ble_controller/esp32_ble_controller.h
@@ -57,7 +57,7 @@ public:
   void add_on_disconnected_callback(std::function<void()>&& trigger_function);
 
   void set_maintenance_service_exposed_after_flash(bool exposed);
-  void set_static_passkey(&char[6]);
+  void set_static_passkey(*char);
 
   void set_security_mode(BLESecurityMode mode) { security_mode = mode; }
   inline BLESecurityMode get_security_mode() const { return security_mode; }

--- a/components/esp32_ble_controller/esp32_ble_controller.h
+++ b/components/esp32_ble_controller/esp32_ble_controller.h
@@ -57,7 +57,7 @@ public:
   void add_on_disconnected_callback(std::function<void()>&& trigger_function);
 
   void set_maintenance_service_exposed_after_flash(bool exposed);
-  void set_static_passkey(char[6]);
+  void set_static_passkey(*char[6]);
 
   void set_security_mode(BLESecurityMode mode) { security_mode = mode; }
   inline BLESecurityMode get_security_mode() const { return security_mode; }

--- a/components/esp32_ble_controller/esp32_ble_controller.h
+++ b/components/esp32_ble_controller/esp32_ble_controller.h
@@ -57,7 +57,7 @@ public:
   void add_on_disconnected_callback(std::function<void()>&& trigger_function);
 
   void set_maintenance_service_exposed_after_flash(bool exposed);
-  void set_static_passkey(std::string key_pass);
+  void set_static_passkey(uint32_t key_pass);
 
   void set_security_mode(BLESecurityMode mode) { security_mode = mode; }
   inline BLESecurityMode get_security_mode() const { return security_mode; }

--- a/components/esp32_ble_controller/esp32_ble_controller.h
+++ b/components/esp32_ble_controller/esp32_ble_controller.h
@@ -57,7 +57,7 @@ public:
   void add_on_disconnected_callback(std::function<void()>&& trigger_function);
 
   void set_maintenance_service_exposed_after_flash(bool exposed);
-  void set_static_passkey(char key_pass[6]);
+  void set_static_passkey(std::string key_pass);
 
   void set_security_mode(BLESecurityMode mode) { security_mode = mode; }
   inline BLESecurityMode get_security_mode() const { return security_mode; }

--- a/components/esp32_ble_controller/esp32_ble_controller.h
+++ b/components/esp32_ble_controller/esp32_ble_controller.h
@@ -57,6 +57,7 @@ public:
   void add_on_disconnected_callback(std::function<void()>&& trigger_function);
 
   void set_maintenance_service_exposed_after_flash(bool exposed);
+  void set_static_passkey(int);
 
   void set_security_mode(BLESecurityMode mode) { security_mode = mode; }
   inline BLESecurityMode get_security_mode() const { return security_mode; }


### PR DESCRIPTION
This allows predefined static passkeys for scenarios where a device doesn't any good outputs for displaying a passkey during pairing