### PR TITLE
Explicit component header file import

### DIFF
--- a/components/esp32_ble_controller/esp32_ble_controller.h
+++ b/components/esp32_ble_controller/esp32_ble_controller.h
@@ -6,6 +6,7 @@
 
 #include <BLEServer.h>
 
+#include "esphome/core/component.h"
 #include "esphome/core/entity_base.h"
 #include "esphome/core/controller.h"
 #include "esphome/core/defines.h"


### PR DESCRIPTION
Without this import compilation was failing.

Log:
```
INFO ESPHome 2024.11.3
INFO Reading configuration /config/esphome/hud.yaml...
INFO Generating C++ source...
INFO Compiling app...
Processing hud (board: esp32-c3-devkitm-1; framework: arduino; platform: platformio/espressif32@5.4.0)
--------------------------------------------------------------------------------
HARDWARE: ESP32C3 160MHz, 320KB RAM, 4MB Flash
 - toolchain-riscv32-esp @ 8.4.0+2021r2-patch5
Dependency Graph
|-- WiFi @ 2.0.0
|-- ESPmDNS @ 2.0.0
|-- Update @ 2.0.0
|-- noise-c @ 0.1.6
|-- Wire @ 2.0.0
|-- ESP32 BLE Arduino @ 2.0.0
Compiling .pioenvs/hud/src/esphome/components/esp32_ble_controller/ble_command.cpp.o
Compiling .pioenvs/hud/src/esphome/components/esp32_ble_controller/ble_component_handler_base.cpp.o
In file included from src/esphome/components/esp32_ble_controller/ble_component_handler_base.cpp:7:
src/esphome/components/esp32_ble_controller/esp32_ble_controller.h:42:44: error: expected class-name before ',' token
 class ESP32BLEController : public Component, private BLESecurityCallbacks, private BLEServerCallbacks {
                                            ^
src/esphome/components/esp32_ble_controller/esp32_ble_controller.h:70:9: error: 'float esphome::esp32_ble_controller::ESP32BLEController::get_setup_priority() const' marked 'override', but does not override
   float get_setup_priority() const override { return setup_priority::PROCESSOR; }
         ^~~~~~~~~~~~~~~~~~
src/esphome/components/esp32_ble_controller/esp32_ble_controller.h:72:8: error: 'void esphome::esp32_ble_controller::ESP32BLEController::setup()' marked 'override', but does not override
   void setup() override;
        ^~~~~
src/esphome/components/esp32_ble_controller/esp32_ble_controller.h:74:8: error: 'void esphome::esp32_ble_controller::ESP32BLEController::dump_config()' marked 'override', but does not override
   void dump_config() override;
        ^~~~~~~~~~~
src/esphome/components/esp32_ble_controller/esp32_ble_controller.h:78:8: error: 'void esphome::esp32_ble_controller::ESP32BLEController::loop()' marked 'override', but does not override
   void loop() override;
        ^~~~
src/esphome/components/esp32_ble_controller/esp32_ble_controller.h: In member function 'float esphome::esp32_ble_controller::ESP32BLEController::get_setup_priority() const':
src/esphome/components/esp32_ble_controller/esp32_ble_controller.h:70:54: error: 'setup_priority' has not been declared
   float get_setup_priority() const override { return setup_priority::PROCESSOR; }
                                                      ^~~~~~~~~~~~~~
*** [.pioenvs/hud/src/esphome/components/esp32_ble_controller/ble_component_handler_base.cpp.o] Error 1
========================== [FAILED] Took 2.56 seconds ==========================
```

Configuration:
```
esphome:
  name: hud
  friendly_name: HUD

esp32:
  board: esp32-c3-devkitm-1
  framework:
    type: arduino

external_components:
  - source: github://wifwucite/esphome-ble-controller@master

globals:
  - id: frame
    type: uint32_t
  - id: speed
    type: float
    initial_value: '0'
  - id: left_turn_signal
    type: bool
    initial_value: 'false'
  - id: right_turn_signal
    type: bool
    initial_value: 'false'
  - id: break_signal
    type: bool
    initial_value: 'false'

esp32_ble_controller:
  security_mode: none
  commands:
    - command: state
      description: Set device state
      on_execute:
        lambda:
          id(speed) = atof(arguments[0].c_str());
          id(left_turn_signal) = atoi(arguments[1].c_str()) > 0;
          id(right_turn_signal) = atoi(arguments[2].c_str()) > 0;
          id(break_signal) = atoi(arguments[3].c_str()) > 0;

# Enable logging
logger:
  level: WARN

# Enable Home Assistant API
api:
  encryption:
    key: !secret api_encryption_key

ota:
  - platform: esphome
    password: !secret ota_password

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password

  # Enable fallback hotspot (captive portal) in case wifi connection fails
  ap:
    ssid: "HUD Fallback Hotspot"
    password: !secret ap_password

i2c:
  sda: GPIO5
  scl: GPIO6
  frequency: 800kHz

display:
  - platform: ssd1306_i2c
    model: SH1106 128x64
    update_interval: 80ms
    rotation: 180°
    lambda: |-
      id(frame)++;
      if (id(break_signal)) it.fill(COLOR_ON);
      it.printf(it.get_width() / 2, 5, id(retro_gaming), id(break_signal) ? COLOR_OFF : COLOR_ON, TextAlign::TOP_CENTER, "%.0f", id(speed));
      if ((id(frame) / 3) % 2 == 0) {
        if (id(left_turn_signal)) it.filled_triangle(15, 0, 15, 63, 0, 31, id(break_signal) ? COLOR_OFF : COLOR_ON);
        if (id(right_turn_signal)) it.filled_triangle(111, 0, 111, 63, 127, 31, id(break_signal) ? COLOR_OFF : COLOR_ON);
      }

font:
  - file: "fonts/Px437_IBM_VGA_8x14.ttf"
    id: retro_gaming
    size: 64
```

Adding this explicit import fixes the issue for me.